### PR TITLE
Define App monad and implement withDb over it

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,24 @@
+steps:
+  - simple_align:
+      cases: true
+      top_level_patterns: true
+      records: true
+
+  - imports:
+      align: group
+      list_align: after_alias
+      pad_module_names: true
+      long_list_align: inline
+      empty_list_align: inherit
+      list_padding: 4
+      separate_lists: false
+      space_surround: false
+
+  - language_pragmas:
+      style: vertical
+      align: true
+      remove_redundant: true
+  - trailing_whitespace: {}
+
+columns: 100
+newline: lf

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # haskell-operden
+
+## Prerequisites
+
+Install PostgreSQL locally and run `createdb operdenstorage`
+
+## Run
+
+```bash
+stack run
+```
+
+Expected output
+```
+[1 of 2] Compiling Main
+[2 of 2] Compiling Paths_haskell_operden
+Linking .stack-work/dist/x86_64-osx/Cabal-2.4.0.1/build/haskell-operden-exe/haskell-operden-exe ...
+
+haskell-operden> copy/register
+Installing library in /Users/...
+Installing executable haskell-operden-exe in /Users/...
+Registering library for haskell-operden-0.1.0.0..
+Migrating: CREATe TABLE "player"("id" SERIAL8  PRIMARY KEY UNIQUE,"name" VARCHAR NOT NULL,"email" VARCHAR NOT NULL)
+[Debug#SQL] CREATe TABLE "player"("id" SERIAL8  PRIMARY KEY UNIQUE,"name" VARCHAR NOT NULL,"email" VARCHAR NOT NULL); []
+Migrating: CREATe TABLE "item"("id" SERIAL8  PRIMARY KEY UNIQUE,"symbol" VARCHAR NOT NULL,"amount" INT8 NOT NULL,"price" DOUBLE PRECISION NOT NULL,"id_player" INT8 NOT NULL,"ts" TIMESTAMP WITH TIME ZONE NOT NULL)
+[Debug#SQL] CREATe TABLE "item"("id" SERIAL8  PRIMARY KEY UNIQUE,"symbol" VARCHAR NOT NULL,"amount" INT8 NOT NULL,"price" DOUBLE PRECISION NOT NULL,"id_player" INT8 NOT NULL,"ts" TIMESTAMP WITH TIME ZONE NOT NULL); []
+Migrating: ALTER TABLE "item" ADD CONSTRAINT "item_id_player_fkey" FOREIGN KEY("id_player") REFERENCES "player"("id")
+[Debug#SQL] ALTER TABLE "item" ADD CONSTRAINT "item_id_player_fkey" FOREIGN KEY("id_player") REFERENCES "player"("id"); []
+[Debug#SQL] INSERT INTO "player"("name","email") VALUES(?,?) RETURNING "id"; [PersistText "Test",PersistText "test@test.com"]
+[Debug#SQL] INSERT INTO "item"("symbol","amount","price","id_player","ts") VALUES(?,?,?,?,?) RETURNING "id"; [PersistText "CASH",PersistInt64 10000,PersistDouble 1.0,PersistInt64 1,PersistUTCTime 2020-01-16 23:08:44.318446 UTC]
+[Debug#SQL] INSERT INTO "item"("symbol","amount","price","id_player","ts") VALUES(?,?,?,?,?) RETURNING "id"; [PersistText "PAH3.DE",PersistInt64 0,PersistDouble 0.0,PersistInt64 1,PersistUTCTime 2020-01-16 23:08:44.318446 UTC]
+keys = ItemKey {unItemKey = SqlBackendKey {unSqlBackendKey = 1}}, ItemKey {unItemKey = SqlBackendKey {unSqlBackendKey = 2}}
+```

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import Lib
+import AppMonad
 
 main :: IO ()
-main = someFunc
+main = testMain

--- a/package.yaml
+++ b/package.yaml
@@ -20,7 +20,7 @@ extra-source-files:
 description:         Please see the README on GitHub at <https://github.com/Pzixel/haskell-operden>
 
 dependencies:
-  - base
+  - base >= 4.7 && < 5
   - aeson
   - attoparsec
   - base-compat
@@ -30,7 +30,6 @@ dependencies:
   - conduit
   - directory
   - esqueleto
-  - exceptions
   - http-media
   - lens
   - lucid
@@ -44,17 +43,16 @@ dependencies:
   - servant-swagger
   - servant-swagger-ui
   - string-conversions
-  - transformers-base
-  - transformers
   - swagger2
   - text
   - time
   - wai
   - warp
+  - exceptions
+  - transformers
   - monad-control
   - unliftio-core
   - resource-pool
-  - conduit-extra
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -7,8 +7,8 @@ maintainer:          "pzixel@gmail.com"
 copyright:           "2020 Pzixel"
 
 extra-source-files:
-- README.md
-- ChangeLog.md
+  - README.md
+  - ChangeLog.md
 
 # Metadata used when publishing your package
 # synopsis:            Operden written in Haskell
@@ -20,34 +20,41 @@ extra-source-files:
 description:         Please see the README on GitHub at <https://github.com/Pzixel/haskell-operden>
 
 dependencies:
-- base >= 4.7 && < 5
-- aeson
-- attoparsec
-- base-compat
-- blaze-html
-- blaze-markup
-- bytestring
-- conduit
-- directory
-- esqueleto
-- http-media
-- lens
-- lucid
-- monad-logger
-- mtl
-- persistent
-- persistent-postgresql
-- persistent-template
-- servant
-- servant-server
-- servant-swagger
-- servant-swagger-ui
-- string-conversions
-- swagger2
-- text
-- time
-- wai
-- warp
+  - base
+  - aeson
+  - attoparsec
+  - base-compat
+  - blaze-html
+  - blaze-markup
+  - bytestring
+  - conduit
+  - directory
+  - esqueleto
+  - exceptions
+  - http-media
+  - lens
+  - lucid
+  - monad-logger
+  - mtl
+  - persistent
+  - persistent-postgresql
+  - persistent-template
+  - servant
+  - servant-server
+  - servant-swagger
+  - servant-swagger-ui
+  - string-conversions
+  - transformers-base
+  - transformers
+  - swagger2
+  - text
+  - time
+  - wai
+  - warp
+  - monad-control
+  - unliftio-core
+  - resource-pool
+  - conduit-extra
 
 library:
   source-dirs: src
@@ -59,27 +66,26 @@ executables:
     main:                Main.hs
     source-dirs:         app
     ghc-options:
-    - -Wall
-    - -threaded
-    - -rtsopts
-    - -with-rtsopts=-N
+      - -Wall
+      - -threaded
+      - -rtsopts
+      - -with-rtsopts=-N
     dependencies:
-    - haskell-operden
+      - haskell-operden
 
 tests:
   haskell-operden-test:
     main:                Spec.hs
     source-dirs:         test
     ghc-options:
-    - -threaded
-    - -rtsopts
-    - -with-rtsopts=-N
+      - -threaded
+      - -rtsopts
+      - -with-rtsopts=-N
     dependencies:
-    - haskell-operden
+      - haskell-operden
 
 default-extensions:
   - DataKinds
-  - DeriveAnyClass
   - DeriveGeneric
   - DerivingStrategies
   - FlexibleInstances

--- a/src/AppMonad.hs
+++ b/src/AppMonad.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE EmptyDataDecls             #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE QuasiQuotes                #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeFamilies               #-}
+
+module AppMonad where
+
+import Control.Monad.Catch     (MonadCatch, MonadThrow)
+import Control.Monad.IO.Class  (MonadIO, liftIO)
+import Control.Monad.IO.Unlift (MonadUnliftIO)
+import Control.Monad.Logger    (NoLoggingT, runStdoutLoggingT)
+import Control.Monad.Reader    (MonadReader, ReaderT(ReaderT), asks, runReaderT)
+import Control.Monad.Trans     (lift)
+
+import Conduit
+import Data.Time
+import Database.Persist.Postgresql
+import Database.Persist.TH
+
+type App = AppT IO
+
+data Env =
+  Env
+    { connStr :: ConnectionString
+    , port    :: Int
+    }
+  deriving (Eq, Show)
+
+newtype AppT m a =
+  AppT (ReaderT Env m a)
+  deriving (Functor, Applicative, Monad, MonadIO, MonadThrow, MonadCatch, MonadReader Env)
+
+deriving instance MonadTrans AppT
+
+deriving instance MonadUnliftIO App
+
+share
+  [mkPersist sqlSettings, mkMigrate "migrateAll"]
+  [persistLowerCase|
+Player
+    name String
+    email String
+    deriving Show
+Item
+    symbol String
+    amount Int
+    price Double
+    idPlayer PlayerId
+    ts UTCTime
+    deriving Show
+|]
+
+type QueryT b a = ReaderT b (NoLoggingT (ResourceT IO)) a
+
+withDb ::
+     forall m b a. (MonadUnliftIO m, IsPersistBackend b, BaseBackend b ~ SqlBackend)
+  => QueryT b a
+  -> AppT m a
+withDb action = do
+  cs <- asks connStr
+  lift $ runStdoutLoggingT $ withPostgresqlPool cs 1 $ liftSqlPersistMPool action
+
+example :: App ()
+example =
+  withDb $ do
+    runMigration migrateAll
+    idPlayer <- insert $ Player "Test" "test@test.com"
+    time <- liftIO getCurrentTime
+    idItem1 <- insert $ Item "CASH" 10000 1.0 idPlayer time
+    idItem2 <- insert $ Item "PAH3.DE" 0 0 idPlayer time
+    liftIO $ putStrLn $ "keys = " <> show idItem1 <> ", " <> show idItem2
+
+runAppT :: Env -> AppT m a -> m a
+runAppT e (AppT ma) = runReaderT ma e
+
+testMain :: IO ()
+testMain = do
+  let env = Env
+        { connStr = "host=localhost dbname=operdenstorage user=pguser password=mycoolpass port=5432"
+        , port = 8080
+        }
+  runAppT env example


### PR DESCRIPTION
I think it is good approach to structure the application. Inside `App` monad we may have API suitable for us and the access to `Env` in every function inside the monad.

`Env` is accessible globally without disadvantages, typical for global singletons. It is suitable for:
1. Configuration parameters, loaded from file or hardcoded.
2. Connection pools (which are interior mutable, but threadsafe).
3. Loggers.
4. Handles to other services, such as AWS or AMQP connectors.

`Persistent` library, however, is very inconvenient to build abstractions over it.